### PR TITLE
Поле для определения что у текущего пользователя нет аватарки

### DIFF
--- a/src/Odnoklassniki.php
+++ b/src/Odnoklassniki.php
@@ -39,7 +39,7 @@ class Odnoklassniki extends AbstractProvider
     public function getResourceOwnerDetailsUrl(AccessToken $token)
     {
         $param = 'application_key='.$this->clientPublic
-            .'&fields=uid,name,first_name,last_name,location,pic_3,gender,locale'
+            .'&fields=uid,name,first_name,last_name,location,pic_3,gender,locale,photo_id'
             .'&method=users.getCurrentUser';
         $sign = md5(str_replace('&', '', $param).md5($token.$this->clientSecret));
         return 'http://api.odnoklassniki.ru/fb.do?'.$param.'&access_token='.$token.'&sig='.$sign;


### PR DESCRIPTION
Добавлено опциональное поле `photo_id`, и в случае если у пользователя нет аватарки, поле `photo_id` будет отсутствовать. 

При этом, если у пользователя нет аватарки, в поле `pic_3` будет ссылка на картинку-заглушку.